### PR TITLE
LUGG-457 Comments should be disabled by default

### DIFF
--- a/luggage_biblio.info
+++ b/luggage_biblio.info
@@ -109,6 +109,7 @@ features[variable][] = biblio_stop_words
 features[variable][] = biblio_style
 features[variable][] = biblio_user_style
 features[variable][] = biblio_view_only_own
+features[variable][] = comment_biblio
 features[variable][] = node_submitted_biblio
 features[variable][] = publishcontent_biblio
 github = https://raw.github.com/isubit/luggage_biblio/master/luggage_biblio.info

--- a/luggage_biblio.strongarm.inc
+++ b/luggage_biblio.strongarm.inc
@@ -431,6 +431,13 @@ function luggage_biblio_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'comment_biblio';
+  $strongarm->value = '1';
+  $export['comment_biblio'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'node_submitted_biblio';
   $strongarm->value = 0;
   $export['node_submitted_biblio'] = $strongarm;


### PR DESCRIPTION
Added strongarm configuration to disable comments by default.

Tested branch on my local machine by pulling it down on a clean Luggage build. It appears to work as expected.
